### PR TITLE
Align Gemini Live client with latest SDK requirements

### DIFF
--- a/hooks/use-websocket-voice.ts
+++ b/hooks/use-websocket-voice.ts
@@ -469,15 +469,15 @@ export function useWebSocketVoice(): WebSocketVoiceHook {
               },
               // Media resolution for video input
               mediaResolution: 'MEDIA_RESOLUTION_LOW', // Low resolution for faster processing
-              callbacks: {
-                onopen: () => {
-                  setIsConnected(true)
-                  setSession({ connectionId: 'direct', isActive: true })
-                },
-                onmessage,
-                onerror: (error: unknown) => setError(`Gemini error: ${(error as Error)?.message || 'unknown'}`),
-                onclose: () => setIsConnected(false),
-              }
+            },
+            callbacks: {
+              onopen: () => {
+                setIsConnected(true)
+                setSession({ connectionId: 'direct', isActive: true })
+              },
+              onmessage,
+              onerror: (error: unknown) => setError(`Gemini error: ${(error as Error)?.message || 'unknown'}`),
+              onclose: () => setIsConnected(false),
             }
           })
 

--- a/hooks/useGeminiLiveAudio.ts
+++ b/hooks/useGeminiLiveAudio.ts
@@ -196,18 +196,18 @@ export function useGeminiLiveAudio({
                 voiceName: 'Zephyr'
               }
             }
-          },
-          callbacks: {
-            onopen: () => {
-              setIsConnected(true)
-              setError(null)
-              onStatusChange?.('connected')
-              logActivity('info', 'Gemini Live session connected')
-            },
-            onmessage: handleMessage,
-            onerror: handleError,
-            onclose: handleClose
           }
+        },
+        callbacks: {
+          onopen: () => {
+            setIsConnected(true)
+            setError(null)
+            onStatusChange?.('connected')
+            logActivity('info', 'Gemini Live session connected')
+          },
+          onmessage: handleMessage,
+          onerror: handleError,
+          onclose: handleClose
         }
       })
       
@@ -225,31 +225,53 @@ export function useGeminiLiveAudio({
   }, [apiKey, modelName, onStatusChange, authenticateUser, checkRateLimit, logActivity, generateCorrelationId, sessionId])
 
   // Handle incoming messages from Gemini
-  const handleMessage = useCallback((event: any) => {
+  const handleMessage = useCallback((message: any) => {
     try {
-      const data = event.data
-      if (data.audio) {
-        // Convert Base64 to ArrayBuffer
-        const binary = atob(data.audio)
-        const len = binary.length
-        const buffer = new ArrayBuffer(len)
-        const view = new Uint8Array(buffer)
-        for (let i = 0; i < len; i++) view[i] = binary.charCodeAt(i)
-        
-        // Play the audio using the audio player's playAudioData method
-        audioPlayer.controls.playAudioData(data.audio)
-        onStatusChange?.('playing')
-        
-        logActivity('info', 'Audio response received and playing', {
-          audioSize: buffer.byteLength,
-          outputTokens: estimateTokens(binary)
-        })
+      const extractBase64 = (payload: any): string | null => {
+        if (!payload) return null
+        if (typeof payload === 'string') return payload
+        if (typeof payload.data === 'string') return payload.data
+        if (typeof payload.audio === 'string') return payload.audio
+        if (payload.audio && typeof payload.audio.data === 'string') return payload.audio.data
+        if (payload.inlineData && typeof payload.inlineData.data === 'string') {
+          return payload.inlineData.data
+        }
+        return null
       }
+
+      const inlinePart = Array.isArray(message?.serverContent?.modelTurn?.parts)
+        ? message.serverContent.modelTurn.parts.find((part: any) => extractBase64(part.inlineData))
+        : null
+
+      const audioBase64 =
+        extractBase64(message) ??
+        extractBase64(message?.data) ??
+        extractBase64(message?.audio) ??
+        extractBase64(message?.inlineData) ??
+        (inlinePart ? extractBase64(inlinePart.inlineData) : null)
+
+      if (!audioBase64) {
+        return
+      }
+
+      const binary = atob(audioBase64)
+      const len = binary.length
+      const buffer = new ArrayBuffer(len)
+      const view = new Uint8Array(buffer)
+      for (let i = 0; i < len; i++) view[i] = binary.charCodeAt(i)
+
+      audioPlayer.controls.playAudioData(audioBase64)
+      onStatusChange?.('playing')
+
+      logActivity('info', 'Audio response received and playing', {
+        audioSize: buffer.byteLength,
+        outputTokens: estimateTokens(binary)
+      })
     } catch (e: any) {
       logActivity('error', 'Failed to handle audio message', { error: e.message })
       handleError(e)
     }
-  }, [audioPlayer, onStatusChange, logActivity])
+  }, [audioPlayer, onStatusChange, logActivity, handleError])
 
   // Handle errors with fallback
   const handleError = useCallback((e: any) => {
@@ -302,7 +324,12 @@ export function useGeminiLiveAudio({
       const b64 = btoa(binary)
       
       // Send to Gemini using the live session
-      sessionRef.current.sendRealtimeInput({ audio: b64 })
+      await sessionRef.current.sendRealtimeInput({
+        audio: {
+          data: b64,
+          mimeType: 'audio/pcm;rate=16000'
+        }
+      })
       
       // Log usage
       const tokens = estimateTokens(binary)

--- a/src/core/live/client.ts
+++ b/src/core/live/client.ts
@@ -2,14 +2,32 @@
 // Unified-approved infra adapter for Gemini Live connections.
 // This centralizes all direct @google/genai usage so hooks/components never import it.
 
-import { GoogleGenAI, Modality } from '@google/genai'
+import {
+  GoogleGenAI,
+  Modality,
+  type GoogleGenAIOptions,
+  type LiveCallbacks,
+  type LiveConnectConfig,
+} from '@google/genai'
+
+type LiveConnectConfigWithLegacyFields = (LiveConnectConfig & {
+  /**
+   * Legacy support: callers previously passed callbacks inside config. We still accept that shape
+   * to avoid breaking older hooks, but callbacks will be lifted to the proper top-level field.
+   */
+  callbacks?: LiveCallbacks
+  responseModalities?: Array<Modality | string>
+}) | null | undefined
 
 export type LiveConnectOptions = {
   apiKey: string
   model?: string
-  // Pass-through bag for the SDK's live.connect options (keep it loose to avoid type friction)
-  // See Google SDK docs for exact shape; we intentionally keep this permissive here.
-  config?: Record<string, unknown>
+  /** Optional Live API configuration bag. */
+  config?: LiveConnectConfigWithLegacyFields
+  /** Optional callbacks for the live session. */
+  callbacks?: LiveCallbacks | null
+  /** Additional client options forwarded to the GoogleGenAI constructor. */
+  clientOptions?: Omit<GoogleGenAIOptions, 'apiKey'>
 }
 
 /**
@@ -17,24 +35,66 @@ export type LiveConnectOptions = {
  * Hooks/components should call this function, not @google/genai directly.
  */
 export async function connectLive(options: LiveConnectOptions) {
-  const { apiKey, model, config } = options
-  const genAI = new GoogleGenAI({ apiKey })
+  const { apiKey, model, config, callbacks, clientOptions } = options
+  const genAI = new GoogleGenAI({
+    apiKey,
+    apiVersion: 'v1alpha',
+    ...clientOptions,
+  })
 
   // sensible default; can be overridden by caller
   const liveModel =
     model ?? 'gemini-2.5-flash-preview-native-audio-dialog'
 
-  // default response modalities if caller didn't specify
-  const mergedConfig: Record<string, unknown> = {
-    responseModalities: [Modality.AUDIO, Modality.TEXT],
-    ...config,
+  const configBag: Record<string, unknown> = {
+    ...(config ?? {}),
   }
+
+  // Lift legacy callbacks out of the config bag if present.
+  let callbacksFromConfig: LiveCallbacks | undefined
+  if (typeof configBag.callbacks !== 'undefined') {
+    callbacksFromConfig = configBag.callbacks as LiveCallbacks
+    delete configBag.callbacks
+  }
+
+  const typedConfig = configBag as LiveConnectConfig
+
+  const normalizeModalities = (
+    modalities?: Array<Modality | string> | null,
+  ): Modality[] => {
+    if (!modalities || modalities.length === 0) {
+      return [Modality.AUDIO, Modality.TEXT]
+    }
+
+    return modalities.map((modality) => {
+      if (typeof modality === 'string') {
+        const upper = modality.toUpperCase()
+        return (
+          (Modality as unknown as Record<string, Modality>)[upper] ??
+          (upper as Modality)
+        )
+      }
+      return modality
+    })
+  }
+
+  const normalizedConfig: LiveConnectConfig = {
+    ...typedConfig,
+    responseModalities: normalizeModalities(
+      (config as LiveConnectConfigWithLegacyFields)?.responseModalities ??
+        typedConfig.responseModalities ??
+        null,
+    ),
+  }
+
+  const resolvedCallbacks = callbacks ?? callbacksFromConfig ?? undefined
 
   // Returns the session object from the SDK (with sendRealtimeInput, close, etc.)
   // Keep the type loose to avoid pinning to SDK internals.
   const session = await genAI.live.connect({
     model: liveModel,
-    ...mergedConfig,
+    ...(resolvedCallbacks ? { callbacks: resolvedCallbacks } : {}),
+    config: normalizedConfig,
   } as any)
 
   return session as any


### PR DESCRIPTION
## Summary
- normalize the Gemini Live adapter to forward callbacks via the new config shape, default preview models to v1alpha, and coerce legacy modality strings
- update the voice hooks to use the revised adapter contract, parse Live API responses for inline audio, and send PCM payloads with mime metadata

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d645f0677083338c859928554f9ced